### PR TITLE
[fix/result loading] 모바일 버전 결과페이지에서 잦은 로딩 스피너 에러 fix

### DIFF
--- a/src/layout/Default.tsx
+++ b/src/layout/Default.tsx
@@ -70,13 +70,11 @@ const Default = () => {
 
         // 이전 위치 정보가 있고, 이전 위치와 새로운 위치의 거리가 100m 이상인 경우에만 업데이트
         if (prevPosition.current && calculateDistance(prevPosition.current, newPosition) >= 100) {
-          console.log('업데이트 된 Position : ', newPosition)
           setPosition(position)
           prevPosition.current = newPosition
         }
         // 이전 위치 정보가 없는 경우에는 새로운 위치 정보를 저장하고 업데이트하지 않음
         else if (!prevPosition.current) {
-          console.log('처음 Position', newPosition)
           setPosition(position)
           prevPosition.current = newPosition
         }

--- a/src/layout/Default.tsx
+++ b/src/layout/Default.tsx
@@ -68,13 +68,15 @@ const Default = () => {
           longitude: position.coords.longitude,
         }
 
-        // 이전 위치 정보가 있고, 이전 위치와 새로운 위치의 거리가 100m 이상인 경우에만 업데이트
-        if (prevPosition.current && calculateDistance(prevPosition.current, newPosition) >= 100) {
+        // 이전 위치 정보가 있고, 이전 위치와 새로운 위치의 거리가 1m 이상인 경우에만 업데이트
+        if (prevPosition.current && calculateDistance(prevPosition.current, newPosition) >= 1) {
+          console.log('업데이트 된 Position : ', newPosition)
           setPosition(position)
           prevPosition.current = newPosition
         }
         // 이전 위치 정보가 없는 경우에는 새로운 위치 정보를 저장하고 업데이트하지 않음
         else if (!prevPosition.current) {
+          console.log('처음 Position', newPosition)
           setPosition(position)
           prevPosition.current = newPosition
         }

--- a/src/layout/Default.tsx
+++ b/src/layout/Default.tsx
@@ -68,8 +68,8 @@ const Default = () => {
           longitude: position.coords.longitude,
         }
 
-        // 이전 위치 정보가 있고, 이전 위치와 새로운 위치의 거리가 1m 이상인 경우에만 업데이트
-        if (prevPosition.current && calculateDistance(prevPosition.current, newPosition) >= 1) {
+        // 이전 위치 정보가 있고, 이전 위치와 새로운 위치의 거리가 100m 이상인 경우에만 업데이트
+        if (prevPosition.current && calculateDistance(prevPosition.current, newPosition) >= 100) {
           console.log('업데이트 된 Position : ', newPosition)
           setPosition(position)
           prevPosition.current = newPosition


### PR DESCRIPTION
### 변경 타입
------------------
- [x] Bug fix

### 기획 및 구현한 내용
------------------
- 모바일 버전의 결과 안내 페이지에서 대략 5초에 한 번씩 로딩 스피너가 도는 에러 fix
- 사용자의 위치가 100m 이상 변경될 때만 새로운 위치 정보 수집하여 재 렌더링

### 변경 사항
----------------------
- src/layout/Default.tsx :  
watchPosition 함수에 새로운 위치 정보를 담는 변수 추가
100m 차이에 따른 경우에만 업데이트 하도록 조건문 추가

### 테스트 방법
----------------------
yarn install && yarn gen && yarn dev로 실행 

1. 옵션 선택 후 결과 페이지에서 로딩 스피너 확인 
2. 100m 움직인 후 로딩 스피너 확인 (스킵하셔도 됩니다..)
혹은 be1576b 커밋에 올려둔 1m 바뀔 때 재렌더링 및 콘솔 로그 확인하셔도 됩니다.

### 구현 내용 (스크린샷, gif) 
----------------------------

![image](https://user-images.githubusercontent.com/106373580/233016621-a83c23ea-b7a4-46d9-8b91-750f60045c0b.png)

